### PR TITLE
Nginx load balance algorithm

### DIFF
--- a/src/ldbls/Ldbls.go
+++ b/src/ldbls/Ldbls.go
@@ -45,17 +45,22 @@ func LdblserMapStuffer(service []config.Service) {
 		for no, proxy := range svc.Proxies {
 			var ldblser LoadBalancer
 			cfg := &utils.LoggerConfig{LogPath: svc.Log, LogSuffix: ".log", LogFormatter: &log.TextFormatter{}, LogLevel: log.DebugLevel}
-			if len(proxy.Target) >= 4 {
-				cfg.LogFileName = "ConsistHash-" + strconv.Itoa(no)
-				cfg.LogOutput, _ = os.OpenFile(cfg.LogPath+cfg.LogFileName+cfg.LogSuffix, os.O_CREATE|os.O_WRONLY, 0755)
-				ldblser = NewDefaultConsistHash(len(proxy.Target), no)
-				ldblser.SetLogger(cfg)
-			} else {
-				cfg.LogFileName = "WeightedRoundRobin-" + strconv.Itoa(no)
-				cfg.LogOutput, _ = os.OpenFile(cfg.LogPath+cfg.LogFileName+cfg.LogSuffix, os.O_CREATE|os.O_WRONLY, 0755)
-				ldblser = NewDefaultWeightedRoundRobin(len(proxy.Target), no)
-				ldblser.SetLogger(cfg)
-			}
+		if len(proxy.Target) >= 4 {
+			cfg.LogFileName = "ConsistHash-" + strconv.Itoa(no)
+			cfg.LogOutput, _ = os.OpenFile(cfg.LogPath+cfg.LogFileName+cfg.LogSuffix, os.O_CREATE|os.O_WRONLY, 0755)
+			ldblser = NewDefaultConsistHash(len(proxy.Target), no)
+			ldblser.SetLogger(cfg)
+		} else if len(proxy.Target) >= 2 {
+			cfg.LogFileName = "WeightedRoundRobin-" + strconv.Itoa(no)
+			cfg.LogOutput, _ = os.OpenFile(cfg.LogPath+cfg.LogFileName+cfg.LogSuffix, os.O_CREATE|os.O_WRONLY, 0755)
+			ldblser = NewDefaultWeightedRoundRobin(len(proxy.Target), no)
+			ldblser.SetLogger(cfg)
+		} else {
+			cfg.LogFileName = "LeastConnections-" + strconv.Itoa(no)
+			cfg.LogOutput, _ = os.OpenFile(cfg.LogPath+cfg.LogFileName+cfg.LogSuffix, os.O_CREATE|os.O_WRONLY, 0755)
+			ldblser = NewDefaultLeastConnections(len(proxy.Target), no)
+			ldblser.SetLogger(cfg)
+		}
 			ldblser.Init(proxy.Target)
 			LdblserMap[proxy.Src] = ldblser
 		}

--- a/src/ldbls/LeastConnections.go
+++ b/src/ldbls/LeastConnections.go
@@ -1,0 +1,113 @@
+package ldbls
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/skyleaworlder/ngoinx/src/config"
+	"github.com/skyleaworlder/ngoinx/src/utils"
+)
+
+// LeastConnections is a struct implement LoadBalancer
+// it selects the node with the lowest served/weight ratio
+// ensuring that higher-weight nodes receive proportionally more requests
+type LeastConnections struct {
+	Size  int
+	No    int
+	Nodes []*LeastConnNode
+	log   *log.Entry
+	mu    sync.Mutex
+}
+
+// NewDefaultLeastConnections is default constructor
+func NewDefaultLeastConnections(size, no int) (lc *LeastConnections) {
+	logger := log.NewEntry(log.New())
+	return &LeastConnections{Size: size, No: no, Nodes: []*LeastConnNode{}, log: logger}
+}
+
+// LeastConnNode is a struct
+// served counts the number of requests this node has handled
+// weight determines the proportional share of traffic
+type LeastConnNode struct {
+	dst    string
+	weight int
+	served int
+}
+
+// Init is to implement interface "LoadBalancer"
+func (lc *LeastConnections) Init(targets []config.Target) (err error) {
+	for _, target := range targets {
+		node := LeastConnNode{dst: target.Dst, weight: target.Weight, served: 0}
+		lc.Nodes = append(lc.Nodes, &node)
+	}
+	return nil
+}
+
+// GetAddr is to implement interface "LoadBalancer"
+// It selects the node with the lowest served/weight ratio.
+// When all nodes reach equal ratios, counters are reset to 0.
+func (lc *LeastConnections) GetAddr(req *http.Request) (addr string, err error) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+
+	var bestNode *LeastConnNode
+	var bestRatio float64 = -1
+
+	for _, node := range lc.Nodes {
+		ratio := float64(node.served) / float64(node.weight)
+
+		// for debug
+		lc.log.WithFields(log.Fields{"node.dst": node.dst, "node.served": node.served, "node.weight": node.weight, "ratio": ratio}).Info(
+			"LeastConnections GetAddr evaluating node",
+		)
+
+		if bestNode == nil || ratio < bestRatio {
+			bestRatio = ratio
+			bestNode = node
+		}
+	}
+
+	bestNode.served++
+	addr = bestNode.dst
+
+	lc.log.WithFields(log.Fields{"chosen": addr, "served": bestNode.served}).Info(
+		"LeastConnections GetAddr selected node",
+	)
+
+	// check if all nodes have reached equal served/weight ratios
+	// if so, reset all counters to allow a fresh cycle
+	allEqual := true
+	firstRatio := float64(lc.Nodes[0].served) / float64(lc.Nodes[0].weight)
+	for _, node := range lc.Nodes[1:] {
+		r := float64(node.served) / float64(node.weight)
+		if r != firstRatio {
+			allEqual = false
+			break
+		}
+	}
+	if allEqual {
+		for _, node := range lc.Nodes {
+			node.served = 0
+		}
+		lc.log.Info("LeastConnections GetAddr: all nodes reached equal ratio, resetting counters")
+	}
+
+	return addr, nil
+}
+
+// SetLogger is to implement interface "LoadBalancer"
+func (lc *LeastConnections) SetLogger(cfg *utils.LoggerConfig) (err error) {
+	// e.g LogPath is "./log/", LogFileName is "LeastConnections-1", LogSuffix is ".log"
+	// then log file is ./log/LeastConnections-1.log
+	logName := cfg.LogPath + cfg.LogFileName + cfg.LogSuffix
+	fd, err := os.OpenFile(logName, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		fmt.Println("ngoinx.ldbls.LeastConnections.SetLogger error: create/open log file", logName, "failed")
+		return err
+	}
+	lc.log = utils.LoggerGenerator(cfg.LogFormatter, fd, cfg.LogLevel)
+	return
+}

--- a/src/test/least_conn_test.go
+++ b/src/test/least_conn_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/skyleaworlder/ngoinx/src/config"
+	"github.com/skyleaworlder/ngoinx/src/ldbls"
+)
+
+func Test_LeastConnections_EqualWeight(t *testing.T) {
+	lc := ldbls.NewDefaultLeastConnections(3, 0)
+	lc.Init([]config.Target{
+		{Dst: "http://127.0.0.1:10081", Weight: 1},
+		{Dst: "http://127.0.0.1:10082", Weight: 1},
+		{Dst: "http://127.0.0.1:10083", Weight: 1},
+	})
+
+	url, _ := url.Parse("http://127.0.0.1:10080/api/v1/test")
+	req := &http.Request{
+		Method: "GET",
+		URL:    url,
+		Header: http.Header{},
+		Body:   http.NoBody,
+	}
+
+	// With equal weights, each node should be selected once before any repeats
+	counts := map[string]int{}
+	for i := 0; i < 9; i++ {
+		addr, err := lc.GetAddr(req)
+		if err != nil {
+			t.Fatal("GetAddr failed:", err)
+		}
+		counts[addr]++
+	}
+
+	// Each node should have been selected exactly 3 times
+	for dst, count := range counts {
+		if count != 3 {
+			t.Errorf("Expected 3 requests for %s, got %d", dst, count)
+		}
+	}
+	fmt.Println("EqualWeight counts:", counts)
+}
+
+func Test_LeastConnections_WeightedDistribution(t *testing.T) {
+	lc := ldbls.NewDefaultLeastConnections(3, 0)
+	lc.Init([]config.Target{
+		{Dst: "http://127.0.0.1:10081", Weight: 1},
+		{Dst: "http://127.0.0.1:10082", Weight: 2},
+		{Dst: "http://127.0.0.1:10083", Weight: 3},
+	})
+
+	url, _ := url.Parse("http://127.0.0.1:10080/api/v1/test")
+	req := &http.Request{
+		Method: "GET",
+		URL:    url,
+		Header: http.Header{},
+		Body:   http.NoBody,
+	}
+
+	// Run through enough requests to see the weight distribution
+	// Weights 1:2:3 means in one full cycle:
+	// node1 gets 1, node2 gets 2, node3 gets 3 = 6 total
+	counts := map[string]int{}
+	for i := 0; i < 6; i++ {
+		addr, err := lc.GetAddr(req)
+		if err != nil {
+			t.Fatal("GetAddr failed:", err)
+		}
+		counts[addr]++
+	}
+
+	fmt.Println("WeightedDistribution counts:", counts)
+
+	// Verify proportional distribution
+	if counts["http://127.0.0.1:10081"] != 1 {
+		t.Errorf("Expected 1 request for :10081 (weight 1), got %d", counts["http://127.0.0.1:10081"])
+	}
+	if counts["http://127.0.0.1:10082"] != 2 {
+		t.Errorf("Expected 2 requests for :10082 (weight 2), got %d", counts["http://127.0.0.1:10082"])
+	}
+	if counts["http://127.0.0.1:10083"] != 3 {
+		t.Errorf("Expected 3 requests for :10083 (weight 3), got %d", counts["http://127.0.0.1:10083"])
+	}
+}
+
+func Test_LeastConnections_SingleTarget(t *testing.T) {
+	lc := ldbls.NewDefaultLeastConnections(1, 0)
+	lc.Init([]config.Target{
+		{Dst: "http://127.0.0.1:10081", Weight: 1},
+	})
+
+	url, _ := url.Parse("http://127.0.0.1:10080/api/v1/test")
+	req := &http.Request{
+		Method: "GET",
+		URL:    url,
+		Header: http.Header{},
+		Body:   http.NoBody,
+	}
+
+	// Single target should always return the same address
+	for i := 0; i < 5; i++ {
+		addr, err := lc.GetAddr(req)
+		if err != nil {
+			t.Fatal("GetAddr failed:", err)
+		}
+		if addr != "http://127.0.0.1:10081" {
+			t.Errorf("Expected http://127.0.0.1:10081, got %s", addr)
+		}
+	}
+	fmt.Println("SingleTarget: all requests correctly routed to single node")
+}


### PR DESCRIPTION
Add a Weighted Least Connections load balancing algorithm to ngoinx to improve server utilization-based routing.

This implementation functions as a "weighted least-served" algorithm, selecting the backend with the lowest `served/weight` ratio, as the `GetAddr` interface lacks a request completion callback for true active connection tracking.

---
<p><a href="https://cursor.com/agents/bc-c59f59b5-ab5b-4acb-a245-e8b43f6ddde3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c59f59b5-ab5b-4acb-a245-e8b43f6ddde3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

